### PR TITLE
Replace software TX/RX control with hardware PTT control

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains a replacement firmware application for the NiceRF SA8x8
 
 In contrast to the official factory firmware, two special commands (PEEK and POKE) enable direct register level control to a module's internal RDA1846S transceiver. Configuration of modules through this low level interface facilitates the use of advanced digital modes that are otherwise inaccessible.
 
-**Note:** This firmware is not yet suitable as a drop-in replacement for the original firmware. Applications using the official factory firmware programming interface are not expected to function properly. Hardware control of PTT (setting RL78 GPIO to enable/disable amplifiers and issue TX/RX commands to RDA1745S) has been implemented.
+**Note:** This firmware is not yet suitable as a drop-in replacement for the original firmware. Applications using the official factory firmware programming interface are not expected to function properly. Hardware control of PTT (setting RL78 GPIO to enable/disable amplifiers and issue TX/RX commands to RDA1846S) has been implemented.
 
 ## Command Set
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains a replacement firmware application for the NiceRF SA8x8
 
 In contrast to the official factory firmware, two special commands (PEEK and POKE) enable direct register level control to a module's internal RDA1846S transceiver. Configuration of modules through this low level interface facilitates the use of advanced digital modes that are otherwise inaccessible.
 
-**Note:** This firmware is not yet suitable as a drop-in replacement for the original firmware. Applications using the official factory firmware programming interface are not expected to function properly.
+**Note:** This firmware is not yet suitable as a drop-in replacement for the original firmware. Applications using the official factory firmware programming interface are not expected to function properly. Hardware control of PTT (setting RL78 GPIO to enable/disable amplifiers and issue TX/RX commands to RDA1745S) has been implemented.
 
 ## Command Set
 

--- a/src/common.h
+++ b/src/common.h
@@ -122,7 +122,7 @@ extern const uint8_t I2C_ADDR_XCVR;
 /*
  * Time management
  */
-void delay(uint16_t n);
+void delay(uint32_t n);
 
 #endif
 

--- a/src/r5f1026a/platform.c
+++ b/src/r5f1026a/platform.c
@@ -454,13 +454,11 @@ void platform_refresh(bool *sq, bool *css, bool *vox) {
   {
     if (PTT_STATE == 0) // Transition from PTT not pressed to PTT pressed
     {
-      
       PTT_STATE = 1; // Execute transmit sequence once
       tmp = i2c_read(I2C_ADDR_XCVR, 0x30); // Read contents of reg 0x30
-      tmp = (tmp & ~(1<<5)) | (1<<6);
+      tmp = (tmp & ~(1<<5)) | (1<<6); // Set bits for TX on and RX off
       P1_bit.no0 = 1; // P10 (RXEN) is high
-      i2c_write(I2C_ADDR_XCVR, 0x30, tmp); // Write tmp to 0x30
-      
+      i2c_write(I2C_ADDR_XCVR, 0x30, tmp); // Write tmp to 0x30 
     }
 
   } else { // If PTT not pressed
@@ -468,7 +466,7 @@ void platform_refresh(bool *sq, bool *css, bool *vox) {
     {
       PTT_STATE = 0; // Execute receive sequence once
       tmp = i2c_read(I2C_ADDR_XCVR, 0x30); // Read contents of reg 0x30
-      tmp = (tmp & ~(1<<6) )| (1<<5);
+      tmp = (tmp & ~(1<<6) )| (1<<5); // Set bits for TX off and RX on
       P1_bit.no0 = 0; // P10 (RXEN) is low
       i2c_write(I2C_ADDR_XCVR, 0x30, tmp); // Write tmp to 0x30
     }


### PR DESCRIPTION
Existing projects using the SA868 will be using the PTT pin for TX/RX control. I propose locking out this control via UART, and instead allowing the module to read the state of the PTT pin and enable/disable amplifiers and issue I2C commands to the RDA1846S. My implementation works by polling the state of PTT on P22 (necessary given no interrupt available on P22) and attempts to optimize performance by detecting the state of PTT, executing TX/RX changes only on that state change. Any attempts to manually set  bits 5 or 6 of reg 0x30 via UART will be treated as an error.